### PR TITLE
Fix dependencies vs. devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,13 +45,13 @@
     "release": "yarn build && yarn changeset publish"
   },
   "dependencies": {
-    "@changesets/cli": "^2.27.7",
     "buffer-image-size": "^0.6.4",
     "docx": "^8.5.0",
     "prosemirror-model": "^1.18.1"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.18.6",
+    "@changesets/cli": "^2.27.7",
     "@curvenote/schema": "0.12.16",
     "@types/jest": "^28.1.3",
     "@types/markdown-it": "^12.2.3",


### PR DESCRIPTION
`@changesets/cli` is only used for development and the build and release process; putting it under `dependencies` means that anything using prosemirror-docx gets many unneeded packages installed.