### PR TITLE
feat: writeDocx returns the buffer to allow .then or await

### DIFF
--- a/.changeset/little-tigers-bathe.md
+++ b/.changeset/little-tigers-bathe.md
@@ -1,0 +1,5 @@
+---
+'prosemirror-docx': minor
+---
+
+Calling writeDocx returns the buffer, which allows for await or .then usage

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ const opts = {
 // Create a doc in memory, and then write it to disk
 const wordDocument = defaultDocxSerializer.serialize(state.doc, opts);
 
-await writeDocx(wordDocument, (buffer) => {
+await writeDocx(wordDocument).then((buffer) => {
   writeFileSync('HelloWorld.docx', buffer);
 });
 ```

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,10 +30,14 @@ export function createDocFromState(state: {
 
 export async function writeDocx(
   doc: Document,
-  write: ((buffer: Buffer) => void) | ((buffer: Buffer) => Promise<void>),
+  /**
+   * @deprecated use `.then()` or `await` instead
+   */
+  write?: ((buffer: Buffer) => void) | ((buffer: Buffer) => Promise<void>),
 ) {
   const buffer = await Packer.toBuffer(doc);
-  return write(buffer);
+  await write?.(buffer);
+  return buffer;
 }
 
 export function getLatexFromNode(node: ProsemirrorNode): string {


### PR DESCRIPTION
This allows the user to use .then or await instead of using old school callbacks