### PR TITLE
Allow users to override the `imageType` - fixes dataurl images

### DIFF
--- a/.changeset/fancy-pigs-shop.md
+++ b/.changeset/fancy-pigs-shop.md
@@ -1,0 +1,5 @@
+---
+'prosemirror-docx': minor
+---
+
+Allow users to pass an `imageType` to the `image` serializer, fixes image serializer for dataUrl images

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -52,6 +52,7 @@ export type IMathOpts = {
   id?: string | null;
   numbered?: boolean;
 };
+export type ImageType = 'jpg' | 'png' | 'gif' | 'bmp';
 
 const MAX_IMAGE_WIDTH = 600;
 
@@ -252,6 +253,7 @@ export class DocxSerializerState {
     widthPercent = 70,
     align: AlignOptions = 'center',
     imageRunOpts?: IImageOptions,
+    imageType?: ImageType,
   ) {
     const buffer = this.options.getImageBuffer(src);
     const dimensions = imageDimensionsFromData(buffer);
@@ -259,12 +261,16 @@ export class DocxSerializerState {
     if (!dimensions) return;
     const aspect = dimensions.height / dimensions.width;
     const width = this.maxImageWidth * (widthPercent / 100);
+    let it;
+    try {
+      it = imageType || (src.replace(/.*\./, '').toLowerCase() as any);
+    } catch (e) {
+      it = 'png';
+    }
     this.current.push(
       new ImageRun({
-        ...imageRunOpts,
         data: buffer,
-        // Assume that the file extension is a valid docx image type.
-        type: src.replace(/.*\./, '').toLowerCase() as any,
+        type: it,
         transformation: {
           ...(imageRunOpts?.transformation || {}),
           width,


### PR DESCRIPTION
* The previous code attempted to parse large dataurls with a regex which resulted in a huge lag, and subsequent failure when the dataurl resulted in an invalid regexc

* this fix allows users to pass in an `imageType`, before falling back to this regex code, and finally defaulting to png if all else fails